### PR TITLE
Remove image upload from products POST

### DIFF
--- a/src/controllers/products/create.js
+++ b/src/controllers/products/create.js
@@ -1,54 +1,6 @@
-const { image, product } = require('../../models')
-const { file } = require('../../utils')
-const path = require('path')
+const { product } = require('../../models')
 const Boom = require('boom')
 const Promise = require('bluebird')
-const appDir = path.dirname(require.main.filename)
-
-const addImages = function (request, originalProduct) {
-  return new Promise(function (resolve, reject) {
-    const images = request.payload.images
-    if (!images || images.length === 0) {
-      resolve(originalProduct)
-    }
-
-    const incrementUploadedFiles = function () {
-      uploadedFiles++
-      if (uploadedFiles === images.length) {
-        product.findOne({
-          include: [{
-            model: image,
-            as: 'image'
-          }],
-          where: { id: originalProduct.id }
-        }).then(productWithImages => {
-          resolve(productWithImages)
-        }).catch(err => reject(Boom.badImplementation('Could not retrieve saved product' + err)))
-      }
-    }
-
-    let uploadedFiles = 0
-    for (const imageUpload of images) {
-      image.create().then(createdImage => {
-        createdImage.addProduct(originalProduct.id)
-          .then(linkedProduct => {
-            const name = `${createdImage.id}-original`
-            const filepath = appDir + '/storage/' + name
-            file.save(filepath, imageUpload, function (err) {
-              if (err) {
-                reject(Boom.badImplementation(err))
-              } else {
-                incrementUploadedFiles()
-              }
-            })
-          })
-          .catch(err => {
-            reject(Boom.badImplementation('Could not add products to image ' + createdImage.id, err))
-          })
-      }).catch(err => console.error(err))
-    }
-  })
-}
 
 const addCategories = function (request, originalProduct) {
   return new Promise(function (resolve, reject) {
@@ -70,20 +22,8 @@ module.exports = (request, reply) => {
   const productParams = Object.assign({}, request.payload)
   product.create(productParams)
     .then(createdProduct => {
-      // add images
-      createdProduct = addImages(request, createdProduct)
-        // use the first image if a primaryImageId isn't passed in
-        .then((productWithImages) => {
-          return new Promise(function (resolve, reject) {
-            if (!productWithImages.primaryImageId && productWithImages.image[0]) {
-              productWithImages.primaryImageId = productWithImages.image[0].id
-              resolve(productWithImages.save())
-            }
-            resolve(productWithImages)
-          })
-        })
-        // add categories
-        .then(addCategories.bind(null, request))
+      // add categories
+      addCategories(request, createdProduct)
         .then(function (res) {
           reply(res)
         })

--- a/src/routes/products.js
+++ b/src/routes/products.js
@@ -45,12 +45,6 @@ module.exports = [
     path: '/products',
     config: {
       handler: productCreate,
-      payload: {
-        output: 'stream',
-        parse: true,
-        allow: 'multipart/form-data',
-        maxBytes: 50000000
-      },
       validate: {
         payload: {
           name: Joi.string().required(),


### PR DESCRIPTION
Removing this from the post, it becomes to complex to manage images in this way on the client. We will upload them separately